### PR TITLE
Add support for passing JSON data to typst's sys.inputs via CLI and P…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install touying
 ## CLI
 
 ```text
-usage: touying compile [-h] [--output OUTPUT] [--root ROOT] [--font-paths [FONT_PATHS ...]] [--start-page START_PAGE] [--count COUNT] [--ppi PPI] [--silent SILENT] [--format {html,pptx,pdf,pdfpc}] input
+usage: touying compile [-h] [--output OUTPUT] [--root ROOT] [--font-paths [FONT_PATHS ...]] [--start-page START_PAGE] [--count COUNT] [--ppi PPI] [--silent SILENT] [--format {html,pptx,pdf,pdfpc}] [--sys-inputs SYS_INPUTS] input
 
 positional arguments:
   input                 Input file
@@ -47,6 +47,8 @@ options:
   --silent SILENT       Run silently
   --format {html,pptx,pdf,pdfpc}
                         Output format
+  --sys-inputs SYS_INPUTS
+                        JSON string to pass to typst's sys.inputs
 ```
 
 For example:
@@ -56,6 +58,24 @@ touying compile example.typ
 ```
 
 You will get a `example.html` file. Open it with your browser and start your presentation :-)
+
+### Passing variables to typst
+
+You can pass variables to your typst files using the `--sys-inputs` parameter:
+
+```sh
+touying compile example.typ --sys-inputs '{"title":"My Presentation","author":"John Doe"}'
+```
+
+In your typst file, you can access these variables like this:
+
+```typst
+#let title = sys.inputs.at("title", default: "Default Title")
+#let author = sys.inputs.at("author", default: "Default Author")
+
+= #title
+By #author
+```
 
 
 ## Use it as a python package

--- a/touying/cli.py
+++ b/touying/cli.py
@@ -2,6 +2,7 @@
 """
 
 import argparse
+import json
 from . import exporter
 
 
@@ -38,8 +39,18 @@ def main():
         default="html",
         help="Output format",
     )
+    parser_compile.add_argument(
+        "--sys-inputs",
+        default=None,
+        help="JSON string to pass to typst's sys.inputs",
+    )
 
     args = parser.parse_args()
+    
+    # Parse the sys_inputs JSON string if provided
+    sys_inputs_dict = {}
+    if args.sys_inputs:
+        sys_inputs_dict = json.loads(args.sys_inputs)
 
     if args.command == "compile":
         if args.format == "html":
@@ -51,6 +62,7 @@ def main():
                 start_page=args.start_page,
                 count=args.count,
                 silent=args.silent,
+                sys_inputs=sys_inputs_dict,
             )
         elif args.format == "pptx":
             exporter.to_pptx(
@@ -62,6 +74,7 @@ def main():
                 count=args.count,
                 ppi=args.ppi,
                 silent=args.silent,
+                sys_inputs=sys_inputs_dict,
             )
         elif args.format == "pdf":
             exporter.to_pdf(
@@ -70,6 +83,7 @@ def main():
                 root=args.root,
                 font_paths=args.font_paths,
                 silent=args.silent,
+                sys_inputs=sys_inputs_dict,
             )
         elif args.format == "pdfpc":
             exporter.to_pdfpc(
@@ -78,6 +92,7 @@ def main():
                 root=args.root,
                 font_paths=args.font_paths,
                 silent=args.silent,
+                sys_inputs=sys_inputs_dict,
             )
         else:
             raise ValueError(f"Unsupported format: {args.format}")

--- a/touying/cli.py
+++ b/touying/cli.py
@@ -51,6 +51,10 @@ def main():
     sys_inputs_dict = {}
     if args.sys_inputs:
         sys_inputs_dict = json.loads(args.sys_inputs)
+        # Validate that all values are strings
+        for key, value in sys_inputs_dict.items():
+            if not isinstance(value, str):
+                raise ValueError(f"Error in sys-inputs: Value for '{key}' must be a string, got {type(value).__name__}")
 
     if args.command == "compile":
         if args.format == "html":

--- a/touying/exporter.py
+++ b/touying/exporter.py
@@ -38,7 +38,8 @@ def to_html(
     # query <pdfpc-file> from typst file
     pdfpc = json.loads(
         typst.query(
-            input, "<pdfpc-file>", root=root, font_paths=font_paths, field="value"
+            input, "<pdfpc-file>", root=root, font_paths=font_paths, field="value",
+            sys_inputs=sys_inputs
         )
     )
     if len(pdfpc) > 0:
@@ -102,7 +103,8 @@ def to_pptx(
     # query <pdfpc-file> from typst file
     pdfpc = json.loads(
         typst.query(
-            input, "<pdfpc-file>", root=root, font_paths=font_paths, field="value"
+            input, "<pdfpc-file>", root=root, font_paths=font_paths, field="value",
+            sys_inputs=sys_inputs
         )
     )
     if len(pdfpc) > 0:

--- a/touying/exporter.py
+++ b/touying/exporter.py
@@ -13,12 +13,13 @@ FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
 
 def to_html(
-    input, root=None, font_paths=[], output=None, start_page=1, count=None, silent=False
+    input, root=None, font_paths=[], output=None, start_page=1, count=None, silent=False, sys_inputs=None
 ):
     if not silent:
         print(f"Compiling typst source file {input}...")
-
-    images = typst.compile(input, root=root, font_paths=font_paths, format="svg")
+    
+    images = typst.compile(input, root=root, font_paths=font_paths,
+                           format="svg", sys_inputs=sys_inputs)
     if type(images) is not list:
         images = [images]
 
@@ -85,13 +86,15 @@ def to_pptx(
     count=None,
     ppi=500,
     silent=False,
+    sys_inputs=None,
 ):
 
     if not silent:
         print(f"Compiling typst source file {input}...")
 
     images = typst.compile(
-        input, root=root, font_paths=font_paths, format="png", ppi=ppi
+        input, root=root, font_paths=font_paths, format="png", ppi=ppi,
+        sys_inputs=sys_inputs
     )
     if type(images) is not list:
         images = [images]
@@ -158,7 +161,7 @@ def to_pptx(
         print(f"Presentation saved to {output}")
 
 
-def to_pdf(input, output=None, root=None, font_paths=[], silent=False):
+def to_pdf(input, output=None, root=None, font_paths=[], silent=False, sys_inputs=None):
     if not silent:
         print(f"Compiling typst source file {input}...")
     if output is None:
@@ -167,10 +170,11 @@ def to_pdf(input, output=None, root=None, font_paths=[], silent=False):
     output_dir = Path(output).parent
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
-    typst.compile(input, output=output, root=root, font_paths=font_paths, format="pdf")
+    typst.compile(input, output=output, root=root, font_paths=font_paths, format="pdf",
+                  sys_inputs=sys_inputs)
 
 
-def to_pdfpc(input, output=None, root=None, font_paths=[], silent=False):
+def to_pdfpc(input, output=None, root=None, font_paths=[], silent=False, sys_inputs=None):
     if not silent:
         print(f"Compiling typst source file {input}...")
 
@@ -192,6 +196,7 @@ def to_pdfpc(input, output=None, root=None, font_paths=[], silent=False):
                 font_paths=font_paths,
                 field="value",
                 one=True,
+                sys_inputs=sys_inputs,
             )
         )
 

--- a/touying/exporter.py
+++ b/touying/exporter.py
@@ -13,7 +13,7 @@ FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
 
 def to_html(
-    input, root=None, font_paths=[], output=None, start_page=1, count=None, silent=False, sys_inputs=None
+    input, root=None, font_paths=[], output=None, start_page=1, count=None, silent=False, sys_inputs={}
 ):
     if not silent:
         print(f"Compiling typst source file {input}...")
@@ -86,7 +86,7 @@ def to_pptx(
     count=None,
     ppi=500,
     silent=False,
-    sys_inputs=None,
+    sys_inputs={},
 ):
 
     if not silent:
@@ -161,7 +161,7 @@ def to_pptx(
         print(f"Presentation saved to {output}")
 
 
-def to_pdf(input, output=None, root=None, font_paths=[], silent=False, sys_inputs=None):
+def to_pdf(input, output=None, root=None, font_paths=[], silent=False, sys_inputs={}):
     if not silent:
         print(f"Compiling typst source file {input}...")
     if output is None:
@@ -174,7 +174,7 @@ def to_pdf(input, output=None, root=None, font_paths=[], silent=False, sys_input
                   sys_inputs=sys_inputs)
 
 
-def to_pdfpc(input, output=None, root=None, font_paths=[], silent=False, sys_inputs=None):
+def to_pdfpc(input, output=None, root=None, font_paths=[], silent=False, sys_inputs={}):
     if not silent:
         print(f"Compiling typst source file {input}...")
 


### PR DESCRIPTION
Resolves #11

I Added a new argument `--sys-inputs`.

typst-py's compile function has a parameter called `sys_inputs`, which expects a `Dict[str, str]`. Thus, I initialize an empty dictionary then populate it based on the value passed via `--sys-inputs`.

Because it expects a `Dict[srt, str]`, the natural fit is that the command line accepts JSON. (Now that I think about it, maybe it should error out if that JSON contains datatypes other than strings).

My team uses this feature a lot.