### PR TITLE
PPTX SVG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ We generate SVG image files and package them with impress.js into an HTML file. 
 
 We generate PNG image files and package them into a PPTX file. This way, you can open and present it using PowerPoint, and it supports speaker notes.
 
+SVGs can also be used (PNGs will be generated even when using SVGs because PPTX needs a raster fallback for older versions, you can use the `ppi` option to lower the PNGs' resolution).
+
 ![image](https://github.com/touying-typ/touying-exporter/assets/34951714/3d547c74-fb4b-4c31-81e5-5138a5d727c9)
 
 ## Install
@@ -29,7 +31,7 @@ pip install touying
 ## CLI
 
 ```text
-usage: touying compile [-h] [--output OUTPUT] [--root ROOT] [--font-paths [FONT_PATHS ...]] [--start-page START_PAGE] [--count COUNT] [--ppi PPI] [--silent SILENT] [--format {html,pptx,pdf,pdfpc}] [--sys-inputs SYS_INPUTS] input
+usage: touying compile [-h] [--output OUTPUT] [--root ROOT] [--font-paths [FONT_PATHS ...]] [--start-page START_PAGE] [--count COUNT] [--ppi PPI] [--svg SVG] [--silent SILENT] [--format {html,pptx,pdf,pdfpc}] [--sys-inputs SYS_INPUTS] input
 
 positional arguments:
   input                 Input file
@@ -44,6 +46,7 @@ options:
                         Page to start from
   --count COUNT         Number of pages to convert
   --ppi PPI             Pixels per inch for PPTX format
+  --svg SVG             Use svg in PPTX format
   --silent SILENT       Run silently
   --format {html,pptx,pdf,pdfpc}
                         Output format

--- a/touying/cli.py
+++ b/touying/cli.py
@@ -31,6 +31,9 @@ def main():
         "--ppi", type=int, default=500, help="Pixels per inch for PPTX format"
     )
     parser_compile.add_argument(
+        "--svg", type=bool, default=False, help="Use svg in PPTX format"
+    )
+    parser_compile.add_argument(
         "--silent", type=bool, default=False, help="Run silently"
     )
     parser_compile.add_argument(
@@ -77,6 +80,7 @@ def main():
                 start_page=args.start_page,
                 count=args.count,
                 ppi=args.ppi,
+                svg=args.svg,
                 silent=args.silent,
                 sys_inputs=sys_inputs_dict,
             )

--- a/touying/exporter.py
+++ b/touying/exporter.py
@@ -1,6 +1,10 @@
 import typst
 from pptx import Presentation
 from pptx.util import Cm
+from pptx.parts.image import ImagePart
+from pptx.opc.constants import RELATIONSHIP_TYPE as RT
+from pptx.oxml.ns import nsdecls
+from pptx.oxml import parse_xml
 from pathlib import Path
 from PIL import Image
 from io import BytesIO
@@ -86,6 +90,7 @@ def to_pptx(
     start_page=1,
     count=None,
     ppi=500,
+    svg=False,
     silent=False,
     sys_inputs={},
 ):
@@ -97,8 +102,15 @@ def to_pptx(
         input, root=root, font_paths=font_paths, format="png", ppi=ppi,
         sys_inputs=sys_inputs
     )
+    if svg:
+        svgs = typst.compile(
+            input, root=root, font_paths=font_paths, format="svg",
+            sys_inputs=sys_inputs
+        )
     if type(images) is not list:
         images = [images]
+        if svg:
+            svgs = [svg]
 
     # query <pdfpc-file> from typst file
     pdfpc = json.loads(
@@ -140,7 +152,28 @@ def to_pptx(
         # add a slide
         slide = prs.slides.add_slide(blank_slide_layout)
         left = top = Cm(0)
-        slide.shapes.add_picture(image_file, left, top, height=prs.slide_height)
+        pic = slide.shapes.add_picture(image_file, left, top, height=prs.slide_height)
+
+
+        # insert svg, png becomes fallback (mandatory)
+        if svg:
+            package = slide.part.package
+            partname = package.next_partname("/ppt/media/image%d.svg")
+            svg_part = ImagePart(partname, "image/svg+xml", package, svgs[page_no])
+
+            rId = slide.part.relate_to(svg_part, RT.IMAGE)
+
+            blip = pic._element.blipFill.blip
+            ext_xml = f"""
+            <a:extLst {nsdecls('a')}>
+                <a:ext uri="{{28A0092B-C50C-407E-A947-70E740481C1C}}">
+                    <asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main"
+                                  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                                  r:embed="{rId}"/>
+                </a:ext>
+            </a:extLst>
+            """
+            blip.append(parse_xml(ext_xml))
 
         # add speaker notes
         if page_no in idx2note:


### PR DESCRIPTION
Adds support for svg in PPTX export. While rendering a png alongside the svg is inevitable (because pptx needs a raster fallback), the rendering can be set at a lower quality using the ppi option without altering the quality to clients that support svg.

Here's a screenshot of a pptx presentation generated using this PR and ppi=1. Evidently the presentation is indeed using the svg, thus this PR.
<img width="3110" height="1920" alt="1775655300" src="https://github.com/user-attachments/assets/f0292606-5886-440f-8f46-a5231bed0714" />

This adds the `--svg` argument which can be set to 1 to enable svg. The default is unchanged.
